### PR TITLE
Install recent version of Arduino-IDE so we can run on 64-bit macOS

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -11,5 +11,9 @@ jobs:
         with: 
           ruby-version: 2.6
       - run: |
+          # Install recent Arduino-IDE, Arduino-CI, and then run test
+          curl -fsSL https://downloads.arduino.cc/arduino-1.8.13-macosx.zip > arduino.zip
+          unzip arduino.zip > /dev/null
+          mv Arduino.app /Users/runner/
           bundle install
           bundle exec arduino_ci_remote.rb


### PR DESCRIPTION
This might be an example to be used elsewhere.